### PR TITLE
Taskbar orderin layer

### DIFF
--- a/Assets/03.Prefabs/UI/TaskBar/TaskBar.prefab
+++ b/Assets/03.Prefabs/UI/TaskBar/TaskBar.prefab
@@ -838,6 +838,8 @@ GameObject:
   - component: {fileID: 3000056268448425198}
   - component: {fileID: 3000056268448425199}
   - component: {fileID: 3000056268448425192}
+  - component: {fileID: 2605500558334869824}
+  - component: {fileID: 6928994214826754518}
   m_Layer: 5
   m_Name: TaskBar
   m_TagString: Untagged
@@ -890,7 +892,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.23529412, g: 0.24313726, b: 0.2509804, a: 0.9019608}
+  m_Color: {r: 0.078431375, g: 0.078431375, b: 0.078431375, a: 1}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -922,6 +924,44 @@ MonoBehaviour:
   taskIconPrefab: {fileID: 1597493977236622863, guid: 67857cebcda95c9498e1674ea22190d5, type: 3}
   taskIconParent: {fileID: 3000056266838161857}
   poolCnt: 10
+--- !u!223 &2605500558334869824
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3000056268448425194}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 1
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_SortingLayerID: -470246667
+  m_SortingOrder: 1
+  m_TargetDisplay: 0
+--- !u!114 &6928994214826754518
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3000056268448425194}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
 --- !u!1001 &8962197337936858638
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -43,6 +43,9 @@ TagManager:
   - name: Window
     uniqueID: 2320722793
     locked: 0
+  - name: Taskbar
+    uniqueID: 3824720629
+    locked: 0
   - name: CutScene
     uniqueID: 554350825
     locked: 0


### PR DESCRIPTION
Window들이 TaskBar를 가리는 오류가 발생

모든 Window들은 TaskBar를 가려서는 안됨

TaskBar에 graphic raycaster와 Canvas를 추가하고
Canvas의 Order in Layer에 WIndow보다 위에있는 Taskbar라는 레이어를 만들어 적용시킴