### PR TITLE
윈도우 전체화면 짤림 현상 해결

### DIFF
--- a/Assets/02.Scripts/UI/Window/Window.cs
+++ b/Assets/02.Scripts/UI/Window/Window.cs
@@ -96,7 +96,7 @@ public abstract class Window : MonoUI, IPointerClickHandler, ISelectable
         if(!windowData.isMaximum)
         {
             Vector2 size = Constant.MAX_CANVAS_SIZE;
-            size.y -= 25;
+            size.y -= 50;
             rectTransform.sizeDelta = size;
 
             windowPos = rectTransform.localPosition;


### PR DESCRIPTION
maxWindow에서 y값을 25뺴는것을 50으로 바꿈